### PR TITLE
Fix bug on number of objects.

### DIFF
--- a/model.py
+++ b/model.py
@@ -147,8 +147,6 @@ class GraphDataset(Dataset):
             self._counts[h] += w
             self._weights[t][h] += w
         self._weights = dict(self._weights)
-        nents = int(np.array(list(self._weights.keys())).max() + 1)
-        assert len(objects) == nents, 'Number of objects do no match'
 
         if unigram_size > 0:
             c = self._counts ** self._dampening


### PR DESCRIPTION
When adjacency list of graph has the maximum node index in a right column the following lines result in an error. 

https://github.com/facebookresearch/poincare-embeddings/blob/35c232207bc62f13c35fee844ccb6932aae70709/model.py#L150-L151

The reason for that is that `self._weights.keys())).max()` takes a maximum of the first endpoint of an edge. For the datasets, where the maximum label is on the second endpoint of an edge, this results in assertion error. 

For example, if idx has the following structure:
0 1
0 2
The total number of objects equals to 3; while `self._weights.keys())).max() + 1` equals to 1. 
Removing assertion resolves the issue.