### PR TITLE
pytorch 0.4.0 bug fix

### DIFF
--- a/model.py
+++ b/model.py
@@ -142,7 +142,7 @@ class GraphDataset(Dataset):
         self._weights = ddict(lambda: ddict(int))
         self._counts = np.ones(len(objects), dtype=np.float)
         for i in range(idx.size(0)):
-            t, h, w = self.idx[i]
+            t, h, w = [int(x) for x in self.idx[i]]
             self._counts[h] += w
             self._weights[t][h] += w
         self._weights = dict(self._weights)
@@ -170,7 +170,7 @@ class SNGraphDataset(GraphDataset):
     model_name = '%s_%s_dim%d'
 
     def __getitem__(self, i):
-        t, h, _ = self.idx[i]
+        t, h, _ = [int(x) for x in self.idx[i]]
         negs = set()
         ntries = 0
         nnegs = self.nnegs


### PR DESCRIPTION
In pytorch latest 0.4.0 version, the Value cannot be used as dictionary's keys.

A simple change to fix this problem