### PR TITLE
fixed python version in makefile

### DIFF
--- a/embed.py
+++ b/embed.py
@@ -9,6 +9,7 @@ import torch as th
 import numpy as np
 import logging
 import argparse
+import torch
 from torch.autograd import Variable
 from collections import defaultdict as ddict
 import torch.multiprocessing as mp
@@ -22,12 +23,14 @@ import sys
 
 def ranking(types, model, distfn):
     lt = th.from_numpy(model.embedding())
-    embedding = Variable(lt, volatile=True)
-    ranks = []
-    ap_scores = []
-    for s, s_types in types.items():
-        s_e = Variable(lt[s].expand_as(embedding), volatile=True)
-        _dists = model.dist()(s_e, embedding).data.cpu().numpy().flatten()
+    embedding = Variable(lt, requires_grad = True)
+    with torch.no_grad():
+        ranks = []
+        ap_scores = []
+        for s, s_types in types.items():
+            s_e = Variable(lt[s].expand_as(embedding), requires_grad = True)
+        with torch.no_grad():
+            _dists = model.dist()(s_e, embedding).data.cpu().numpy().flatten()
         _dists[s] = 1e+12
         _labels = np.zeros(embedding.size(0))
         _dists_masked = _dists.copy()

--- a/model.py
+++ b/model.py
@@ -143,6 +143,9 @@ class GraphDataset(Dataset):
         self._counts = np.ones(len(objects), dtype=np.float)
         for i in range(idx.size(0)):
             t, h, w = self.idx[i]
+            t = int(t)
+            h = int(h)
+            w = int(w)
             self._counts[h] += w
             self._weights[t][h] += w
         self._weights = dict(self._weights)
@@ -171,6 +174,8 @@ class SNGraphDataset(GraphDataset):
 
     def __getitem__(self, i):
         t, h, _ = self.idx[i]
+        t = int(t)
+        h = int(h)
         negs = set()
         ntries = 0
         nnegs = self.nnegs

--- a/train-nouns.sh
+++ b/train-nouns.sh
@@ -14,7 +14,7 @@ export OMP_NUM_THREADS=1
 # reported in [Nickel, Kiela, 2017]
 # For MAP results, replace the learning rate parameter with -lr 2.0
 
-python3 embed.py \
+python3.6 embed.py \
        -dim 10 \
        -lr 1.0 \
        -epochs 1500 \

--- a/wordnet/Makefile
+++ b/wordnet/Makefile
@@ -1,4 +1,4 @@
-PYTHON=python3
+PYTHON=python3.6
 
 mammal_closure.tsv: noun_closure.tsv
 	cat noun_closure.tsv | grep -e "\smammal.n.01" | cut -f1 | sed 's/\(.*\)/\^\1/g' > mammals.txt


### PR DESCRIPTION
The python version specified in the makefile is not sufficient as the code only runs on python 3.6 and above. Specified Python version 3.6