### PR TITLE
modifies shell script to use correct python version

### DIFF
--- a/train-mammals.sh
+++ b/train-mammals.sh
@@ -5,7 +5,7 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
-python3 embed.py \
+python embed.py \
        -dim 5 \
        -lr 0.3 \
        -epochs 300 \


### PR DESCRIPTION
Going through the code instructions on Mac OSX gave the following error:

> ModuleNotFoundError: No module named 'torch'

Which was resolved by modifying `python3` to `python`.