### PR TITLE
In the Euclidian space, the distance is incorrectly squared

### DIFF
--- a/hype/manifolds/euclidean.py
+++ b/hype/manifolds/euclidean.py
@@ -26,7 +26,7 @@ class EuclideanManifold(Manifold):
         return u
 
     def distance(self, u, v):
-        return (u - v).pow(2).sum(dim=-1)
+        return (u - v).pow(2).sum(dim=-1).sqrt()
 
     def rgrad(self, p, d_p):
         return d_p


### PR DESCRIPTION
In the formula `angle_at_u(...)`, dist is used squared in the numerator, and unsquared in the denominator. Thus, this does not expect `distance(...)` to return a squared norm but a true norm.

> ![image](https://user-images.githubusercontent.com/364405/142433910-6f4ce393-8ad8-48c2-b1df-d5860a434a98.png)
> ![image](https://user-images.githubusercontent.com/364405/142433969-76636e27-1850-4d3c-89ab-b3306ece658d.png)

You can notice the inconsistency if you put `norm(...)` and `distance(...)` next to each other:
> ![image](https://user-images.githubusercontent.com/364405/142434118-eea10611-e476-4e8c-a38e-38bdd215b15b.png)
